### PR TITLE
serve: add simple local server and make task to call it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ copy_wasm_exec:
 build: build_wasm copy_wasm_exec
 
 run: build
-	serve ./public
+	go run ./serve
+
+run_tinygo: build_tinygo
+	go run ./serve
 
 build_wasm_tinygo:
 	tinygo build -o ./public/vita.wasm -target wasm .

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"strings"
+)
+
+const dir = "./public"
+
+func main() {
+	fs := http.FileServer(http.Dir(dir))
+	log.Print("Serving " + dir + " on http://localhost:8080")
+	http.ListenAndServe(":8080", http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		resp.Header().Add("Cache-Control", "no-cache")
+		if strings.HasSuffix(req.URL.Path, ".wasm") {
+			resp.Header().Set("content-type", "application/wasm")
+		}
+		fs.ServeHTTP(resp, req)
+	}))
+}


### PR DESCRIPTION
This PR makes the small addition of the missing local server, and also modifies the Makefile to run it, alongside a TinyGo version of the same thing.