### PR TITLE
lib/game: ReaderWriter implementation, and some helpers

### DIFF
--- a/lib/game/errors.go
+++ b/lib/game/errors.go
@@ -1,0 +1,9 @@
+package game
+
+import (
+	"errors"
+)
+
+var (
+	errInvalidLength = errors.New("slice does not match universe size")
+)

--- a/lib/game/universe.go
+++ b/lib/game/universe.go
@@ -39,6 +39,20 @@ func (u *Universe) Width() uint32 {
 	return u.width
 }
 
+func (u *Universe) Size() int {
+	return len(u.cells)
+}
+
+func (u *Universe) Dead() bool {
+	for i := range u.cells {
+		if u.cells[i] == Alive {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (u *Universe) Cell(idx uint32) uint8 {
 	return u.cells[idx]
 }
@@ -115,6 +129,24 @@ func (u *Universe) SetRectangle(startingRow, startingColumn uint32, values [][]u
 			u.cells[idx] = value
 		}
 	}
+}
+
+func (u *Universe) Read(p []byte) (n int, err error) {
+	if len(p) != u.Size() {
+		return 0, errInvalidLength
+	}
+
+	copy(p, u.cells)
+	return len(p), nil
+}
+
+func (u *Universe) Write(p []byte) (n int, err error) {
+	if len(p) != u.Size() {
+		return 0, errInvalidLength
+	}
+
+	copy(u.cells, p)
+	return len(p), nil
 }
 
 func rule(state uint8, liveNeighbors uint8) uint8 {

--- a/lib/game/universe_test.go
+++ b/lib/game/universe_test.go
@@ -128,4 +128,47 @@ func TestUniverse(t *testing.T) {
 			t.Errorf("Expected cell to be dead, got %d", rule(Dead, 4))
 		}
 	})
+
+	t.Run("ReaderWriter", func(t *testing.T) {
+		u := NewUniverse(24, 32)
+		u.Randomize(50)
+		if u.Dead() {
+			t.Errorf("Expected universe to be alive, got dead")
+		}
+
+		data := make([]byte, u.Size())
+		u.Read(data)
+
+		u2 := NewUniverse(24, 32)
+		if !u2.Dead() {
+			t.Errorf("Expected universe to be dead, got alive")
+		}
+
+		u2.Write(data)
+
+		if u2.Dead() {
+			t.Errorf("Expected universe to be alive, got dead")
+		}
+
+		var i uint32
+		for i = 0; i < uint32(u.Size()); i++ {
+			if u.Cell(i) != u2.Cell(i) {
+				t.Errorf("Expected cell %d in u2 to be %d, got %d", i, u.Cell(uint32(i)), u2.Cell(uint32(i)))
+			}
+		}
+	})
+
+	t.Run("Read and Write when invalid", func(t *testing.T) {
+		u := NewUniverse(24, 32)
+		u.Randomize(50)
+
+		data := make([]byte, 10)
+		if _, err := u.Read(data); err != errInvalidLength {
+			t.Errorf("Expected error to be %v, got %v", errInvalidLength, err)
+		}
+
+		if _, err := u.Write(data); err != errInvalidLength {
+			t.Errorf("Expected error to be %v, got %v", errInvalidLength, err)
+		}
+	})
 }


### PR DESCRIPTION
This PR implements the `ReaderWriter` interface, so that a `Universe` can be loaded or saved. It also adds functions `universe.Dead()` and `universe.Size()` to make the syntax a little more appealing.