### PR TITLE
lib/game: separate the rule and neighbor functions for the standard Conway game

### DIFF
--- a/lib/game/conway.go
+++ b/lib/game/conway.go
@@ -1,0 +1,54 @@
+package game
+
+// ConwayRules implements the classic Game of Life rules.
+func (u *Universe) ConwayRules(cell uint8, row, column uint32) uint8 {
+	return RuleB3S23(cell, u.MooreNeighbors(row, column))
+}
+
+// RuleB3S23 implements the B3/S23 ruleset:
+// https://www.conwaylife.com/wiki/Conway%27s_Game_of_Life#Rules
+func RuleB3S23(cell uint8, liveNeighbors uint8) uint8 {
+	switch {
+	case cell == Alive && liveNeighbors < 2:
+		// 1. Any live cell with fewer than two live neighbours dies, as if by underpopulation.
+		return Dead
+	case cell == Alive && (liveNeighbors == 2 || liveNeighbors == 3):
+		// 2. Any live cell with two or three live neighbours lives on to the next generation.
+		return Alive
+	case cell == Alive && liveNeighbors > 3:
+		// 3. Any live cell with more than three live neighbours dies, as if by overpopulation.
+		return Dead
+	case cell == Dead && liveNeighbors == 3:
+		// 4. Any dead cell with exactly three live neighbours becomes a live cell, as if by reproduction.
+		return Alive
+	default:
+		return cell
+	}
+}
+
+// MooreNeighbors returns the number of alive neighbors for a given cell.
+// It uses the Moore neighborhood, which includes the eight cells surrounding
+// the given cell.
+func (u *Universe) MooreNeighbors(row, column uint32) uint8 {
+	count := uint8(0)
+
+	// We use height/width and modulos to avoid manually handling edge cases
+	// (literally: cases at the edge of the universe, e.g. cells at row/col 0).
+	for _, rowDiff := range []uint32{u.height - 1, 0, 1} {
+		for _, colDiff := range []uint32{u.width - 1, 0, 1} {
+			if rowDiff == 0 && colDiff == 0 {
+				// Skip checking the cell itself
+				continue
+			}
+
+			neighborRow := (row + rowDiff) % u.height
+			neighborColumn := (column + colDiff) % u.width
+			neighborIdx := u.GetIndex(neighborRow, neighborColumn)
+			if u.Cell(neighborIdx) == Alive {
+				count++
+			}
+		}
+	}
+
+	return count
+}

--- a/lib/game/conway_test.go
+++ b/lib/game/conway_test.go
@@ -1,0 +1,76 @@
+package game
+
+import (
+	"testing"
+)
+
+func TestConwayRule(t *testing.T) {
+	t.Run("MooreNeighbors", func(t *testing.T) {
+		u := NewUniverse(32, 32)
+
+		idx := u.GetIndex(12, 12)
+		u.cells[idx] = Alive
+		if u.Cell(idx) != Alive {
+			t.Errorf("Expected cell %d to be alive, got %d", idx, u.Cell(idx))
+		}
+
+		if u.MooreNeighbors(0, 0) != 0 {
+			t.Errorf("Expected cell %d to have 0 alive neighbors, got %d", 0, u.MooreNeighbors(0, 0))
+		}
+
+		if u.MooreNeighbors(11, 12) != 1 {
+			t.Errorf("Expected cell %d to have 1 alive neighbors, got %d", idx, u.MooreNeighbors(11, 12))
+		}
+
+		idx = u.GetIndex(10, 12)
+		u.cells[idx] = Alive
+
+		if u.MooreNeighbors(11, 12) != 2 {
+			t.Errorf("Expected cell %d to have 2 alive neighbors, got %d", idx, u.MooreNeighbors(11, 12))
+		}
+	})
+
+	t.Run("RuleB3S23 when cell is Alive", func(t *testing.T) {
+		if RuleB3S23(Alive, 0) != Dead {
+			t.Errorf("Expected cell to be dead, got %d", RuleB3S23(Alive, 0))
+		}
+
+		if RuleB3S23(Alive, 1) != Dead {
+			t.Errorf("Expected cell to be dead, got %d", RuleB3S23(Alive, 1))
+		}
+
+		if RuleB3S23(Alive, 2) != Alive {
+			t.Errorf("Expected cell to be alive, got %d", RuleB3S23(Alive, 2))
+		}
+
+		if RuleB3S23(Alive, 3) != Alive {
+			t.Errorf("Expected cell to be alive, got %d", RuleB3S23(Alive, 3))
+		}
+
+		if RuleB3S23(Alive, 4) != Dead {
+			t.Errorf("Expected cell to be dead, got %d", RuleB3S23(Alive, 4))
+		}
+	})
+
+	t.Run("RuleB3S23 when cell is Dead", func(t *testing.T) {
+		if RuleB3S23(Dead, 0) != Dead {
+			t.Errorf("Expected cell to be dead, got %d", RuleB3S23(Dead, 0))
+		}
+
+		if RuleB3S23(Dead, 1) != Dead {
+			t.Errorf("Expected cell to be dead, got %d", RuleB3S23(Dead, 1))
+		}
+
+		if RuleB3S23(Dead, 2) != Dead {
+			t.Errorf("Expected cell to be dead, got %d", RuleB3S23(Dead, 2))
+		}
+
+		if RuleB3S23(Dead, 3) != Alive {
+			t.Errorf("Expected cell to be alive, got %d", RuleB3S23(Dead, 3))
+		}
+
+		if RuleB3S23(Dead, 4) != Dead {
+			t.Errorf("Expected cell to be dead, got %d", RuleB3S23(Dead, 4))
+		}
+	})
+}

--- a/lib/game/universe_test.go
+++ b/lib/game/universe_test.go
@@ -24,31 +24,6 @@ func TestUniverse(t *testing.T) {
 		}
 	})
 
-	t.Run("AliveNeighbors", func(t *testing.T) {
-		u := NewUniverse(32, 32)
-
-		idx := u.GetIndex(12, 12)
-		u.cells[idx] = Alive
-		if u.Cell(idx) != Alive {
-			t.Errorf("Expected cell %d to be alive, got %d", idx, u.Cell(idx))
-		}
-
-		if u.AliveNeighbors(0, 0) != 0 {
-			t.Errorf("Expected cell %d to have 0 alive neighbors, got %d", 0, u.AliveNeighbors(0, 0))
-		}
-
-		if u.AliveNeighbors(11, 12) != 1 {
-			t.Errorf("Expected cell %d to have 1 alive neighbors, got %d", idx, u.AliveNeighbors(11, 12))
-		}
-
-		idx = u.GetIndex(10, 12)
-		u.cells[idx] = Alive
-
-		if u.AliveNeighbors(11, 12) != 2 {
-			t.Errorf("Expected cell %d to have 2 alive neighbors, got %d", idx, u.AliveNeighbors(11, 12))
-		}
-	})
-
 	t.Run("Tick", func(t *testing.T) {
 		u := NewUniverse(24, 32)
 		u.cells[u.GetIndex(10, 12)] = Alive
@@ -58,12 +33,12 @@ func TestUniverse(t *testing.T) {
 
 		u.Tick()
 
-		if u.AliveNeighbors(0, 0) != 0 {
-			t.Errorf("Expected cell %d to have 0 alive neighbors, got %d", 0, u.AliveNeighbors(0, 0))
+		if u.MooreNeighbors(0, 0) != 0 {
+			t.Errorf("Expected cell %d to have 0 alive neighbors, got %d", 0, u.MooreNeighbors(0, 0))
 		}
 
-		if u.AliveNeighbors(11, 12) != 6 {
-			t.Errorf("Expected cell %d to have 6 alive neighbors, got %d", 0, u.AliveNeighbors(11, 12))
+		if u.MooreNeighbors(11, 12) != 6 {
+			t.Errorf("Expected cell %d to have 6 alive neighbors, got %d", 0, u.MooreNeighbors(11, 12))
 		}
 
 		u.Tick()
@@ -72,60 +47,16 @@ func TestUniverse(t *testing.T) {
 			t.Errorf("Expected cell %d to be dead, got %d", u.GetIndex(11, 12), u.Cell(u.GetIndex(11, 12)))
 		}
 
-		if u.AliveNeighbors(11, 12) != 5 {
-			t.Errorf("Expected cell %d to have 5 alive neighbors, got %d", u.GetIndex(11, 12), u.AliveNeighbors(11, 12))
+		if u.MooreNeighbors(11, 12) != 5 {
+			t.Errorf("Expected cell %d to have 5 alive neighbors, got %d", u.GetIndex(11, 12), u.MooreNeighbors(11, 12))
 		}
 
 		if u.Cell(u.GetIndex(11, 13)) != Dead {
 			t.Errorf("Expected cell %d to be dead, got %d", u.GetIndex(11, 12), u.Cell(u.GetIndex(11, 12)))
 		}
 
-		if u.AliveNeighbors(11, 13) != 3 {
-			t.Errorf("Expected cell %d to have 3 alive neighbors, got %d", u.GetIndex(11, 13), u.AliveNeighbors(11, 13))
-		}
-	})
-
-	t.Run("Rule when cell is Alive", func(t *testing.T) {
-		if rule(Alive, 0) != Dead {
-			t.Errorf("Expected cell to be dead, got %d", rule(Alive, 0))
-		}
-
-		if rule(Alive, 1) != Dead {
-			t.Errorf("Expected cell to be dead, got %d", rule(Alive, 1))
-		}
-
-		if rule(Alive, 2) != Alive {
-			t.Errorf("Expected cell to be alive, got %d", rule(Alive, 2))
-		}
-
-		if rule(Alive, 3) != Alive {
-			t.Errorf("Expected cell to be alive, got %d", rule(Alive, 3))
-		}
-
-		if rule(Alive, 4) != Dead {
-			t.Errorf("Expected cell to be dead, got %d", rule(Alive, 4))
-		}
-	})
-
-	t.Run("Rule when cell is Dead", func(t *testing.T) {
-		if rule(Dead, 0) != Dead {
-			t.Errorf("Expected cell to be dead, got %d", rule(Dead, 0))
-		}
-
-		if rule(Dead, 1) != Dead {
-			t.Errorf("Expected cell to be dead, got %d", rule(Dead, 1))
-		}
-
-		if rule(Dead, 2) != Dead {
-			t.Errorf("Expected cell to be dead, got %d", rule(Dead, 2))
-		}
-
-		if rule(Dead, 3) != Alive {
-			t.Errorf("Expected cell to be alive, got %d", rule(Dead, 3))
-		}
-
-		if rule(Dead, 4) != Dead {
-			t.Errorf("Expected cell to be dead, got %d", rule(Dead, 4))
+		if u.MooreNeighbors(11, 13) != 3 {
+			t.Errorf("Expected cell %d to have 3 alive neighbors, got %d", u.GetIndex(11, 13), u.MooreNeighbors(11, 13))
 		}
 	})
 


### PR DESCRIPTION
This PR modifies `lib/game` to separate the rule function for the standard Conway game and for the standard Moore neighbor function to make it easier to extend or modify them for different behaviors.