### PR TITLE
lib/game: use crypto/rand so that the entropy is higher

### DIFF
--- a/lib/game/rand.go
+++ b/lib/game/rand.go
@@ -1,0 +1,15 @@
+package game
+
+import (
+	"crypto/rand"
+)
+
+func randomNumber() int {
+	var b [1]byte
+	rand.Read(b[:])
+	val := int(b[0])
+	if val > 100 {
+		val = val >> 1
+	}
+	return val
+}

--- a/lib/game/rand_test.go
+++ b/lib/game/rand_test.go
@@ -1,0 +1,15 @@
+package game
+
+import (
+	"testing"
+)
+
+func TestRandomness(t *testing.T) {
+	val1 := randomNumber()
+	val2 := randomNumber()
+	val3 := randomNumber()
+
+	if val1 == val2 || val1 == val3 || val2 == val3 {
+		t.Errorf("Expected %d and %d and %d to be different", val1, val2, val3)
+	}
+}

--- a/lib/game/universe.go
+++ b/lib/game/universe.go
@@ -1,9 +1,5 @@
 package game
 
-import (
-	"math/rand"
-)
-
 const (
 	Dead = iota
 	Alive
@@ -96,7 +92,7 @@ func (u *Universe) Reset() {
 
 func (u *Universe) Randomize(livePopulation int) {
 	for i := range u.cells {
-		if rand.Intn(100) < livePopulation {
+		if randomNumber() < livePopulation {
 			u.cells[i] = Alive
 		} else {
 			u.cells[i] = Dead

--- a/lib/game/universe_test.go
+++ b/lib/game/universe_test.go
@@ -33,6 +33,10 @@ func TestUniverse(t *testing.T) {
 
 		u.Tick()
 
+		if u.Stable() {
+			t.Errorf("Expected universe to not be stable")
+		}
+
 		if u.MooreNeighbors(0, 0) != 0 {
 			t.Errorf("Expected cell %d to have 0 alive neighbors, got %d", 0, u.MooreNeighbors(0, 0))
 		}
@@ -42,6 +46,10 @@ func TestUniverse(t *testing.T) {
 		}
 
 		u.Tick()
+
+		if u.Stable() {
+			t.Errorf("Expected universe to not be stable")
+		}
 
 		if u.Cell(u.GetIndex(11, 12)) != Dead {
 			t.Errorf("Expected cell %d to be dead, got %d", u.GetIndex(11, 12), u.Cell(u.GetIndex(11, 12)))
@@ -71,6 +79,12 @@ func TestUniverse(t *testing.T) {
 		u.cells[u.GetIndex(4, 2)] = Alive
 		u.cells[u.GetIndex(2, 3)] = Alive
 		u.cells[u.GetIndex(3, 3)] = Alive
+
+		u.Tick()
+
+		if !u.Stable() {
+			t.Errorf("Expected universe to be stable")
+		}
 
 		u.Tick()
 


### PR DESCRIPTION
This PR modifies `lib/game` to use `crypto/rand` so that the entropy is higher on devices like microcontrollers.