### PR TITLE
multiverse draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.spin/
 *.wasm
 wasm_exec.js

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/acifani/vita
 
 go 1.21
+
+require github.com/fermyon/spin/sdk/go/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/fermyon/spin/sdk/go/v2 v2.0.0 h1:pMq2BxXio9gsBdPVNCuebCsLSt64yaTS3kV2l1gL088=
+github.com/fermyon/spin/sdk/go/v2 v2.0.0/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=

--- a/lib/game/conway.go
+++ b/lib/game/conway.go
@@ -44,6 +44,18 @@ func (u *Universe) MooreNeighbors(row, column uint32) uint8 {
 			neighborRow := (row + rowDiff) % u.height
 			neighborColumn := (column + colDiff) % u.width
 			neighborIdx := u.GetIndex(neighborRow, neighborColumn)
+
+			// If we are in a multiverse,
+			// and we are at column 0,
+			// and we would check neighbors at column-1,
+			// then we want to check the information given by the other universe instead
+			if u.multiverse && column == 0 && colDiff == u.width-1 {
+				if u.multiverseColumn[neighborRow] == Alive {
+					count++
+					continue
+				}
+			}
+
 			if u.Cell(neighborIdx) == Alive {
 				count++
 			}

--- a/lib/game/conway_test.go
+++ b/lib/game/conway_test.go
@@ -30,6 +30,26 @@ func TestConwayRule(t *testing.T) {
 		}
 	})
 
+	t.Run("MooreNeighbors in multiverse", func(t *testing.T) {
+		u := NewMultiverse(4, 4)
+		u.MakeContact([]uint8{0, 1, 1, 0})
+
+		expected := [][]uint8{
+			{1, 0, 0, 0},
+			{2, 0, 0, 0},
+			{2, 0, 0, 0},
+			{1, 0, 0, 0},
+		}
+
+		for row := uint32(0); row < 4; row++ {
+			for col := uint32(0); col < 4; col++ {
+				if u.MooreNeighbors(row, col) != expected[row][col] {
+					t.Errorf("Expected cell %d,%d to have 1 alive neighbors, got %d", row, col, u.MooreNeighbors(0, 0))
+				}
+			}
+		}
+	})
+
 	t.Run("RuleB3S23 when cell is Alive", func(t *testing.T) {
 		if RuleB3S23(Alive, 0) != Dead {
 			t.Errorf("Expected cell to be dead, got %d", RuleB3S23(Alive, 0))

--- a/lib/game/universe.go
+++ b/lib/game/universe.go
@@ -15,6 +15,9 @@ type Universe struct {
 	cells    []uint8
 	newCells []uint8
 
+	multiverse       bool
+	multiverseColumn []uint8
+
 	Rules func(cell uint8, row, column uint32) uint8
 }
 
@@ -29,6 +32,13 @@ func NewUniverse(height, width uint32) *Universe {
 		newCells: newCells,
 	}
 	u.Rules = u.ConwayRules
+	return u
+}
+
+func NewMultiverse(height, width uint32) *Universe {
+	u := NewUniverse(height, width)
+	u.multiverse = true
+	u.multiverseColumn = make([]uint8, height)
 	return u
 }
 
@@ -125,4 +135,25 @@ func (u *Universe) Write(p []byte) (n int, err error) {
 
 	copy(u.cells, p)
 	return len(p), nil
+}
+
+func (u *Universe) MakeContact(column []uint8) {
+	if len(column) == int(u.height) {
+		copy(u.multiverseColumn, column)
+	}
+}
+
+func (u *Universe) Draw() string {
+	drawing := ""
+	for idx, cell := range u.cells {
+		if idx > 0 && idx%int(u.height) == 0 {
+			drawing += "\n"
+		}
+
+		if cell == Alive {
+			drawing += "O "
+		} else {
+			drawing += ". "
+		}
+	}
 }

--- a/lib/game/universe.go
+++ b/lib/game/universe.go
@@ -156,4 +156,6 @@ func (u *Universe) Draw() string {
 			drawing += ". "
 		}
 	}
+
+	return drawing
 }

--- a/multiverse/wasi.go
+++ b/multiverse/wasi.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+
+	"github.com/acifani/vita/lib/game"
+	"github.com/fermyon/spin/sdk/go/v2/redis"
+	"github.com/fermyon/spin/sdk/go/v2/variables"
+)
+
+const (
+	width  = 32
+	height = 32
+)
+
+func init() {
+	redis.Handle(func(payload []byte) error {
+		incomingMsg := string(payload)
+		fmt.Println("incoming message:", incomingMsg)
+		localState := make([]byte, width*height)
+		remoteState := make([]byte, width*height)
+
+		stringID, err := variables.Get("local_id")
+		if err != nil {
+			return errorLogger(err)
+		}
+		id, err := strconv.Atoi(stringID)
+		if err != nil {
+			return errorLogger(err)
+		}
+		key := "universe-" + stringID
+		fmt.Println("I am", key)
+
+		senderID, err := strconv.Atoi(incomingMsg[:1])
+		if err != nil {
+			return errorLogger(err)
+		}
+
+		if senderID != id-1 {
+			// Skipping message, it's not for us
+			fmt.Println("skipping message")
+			return nil
+		}
+
+		redisHost, err := variables.Get("redis_host")
+		if err != nil {
+			return errorLogger(err)
+		}
+
+		db := redis.NewClient(redisHost)
+
+		universe := game.NewUniverse(height, width)
+		res, err := db.Execute("EXISTS", key)
+		if err != nil {
+			return errorLogger(err)
+		}
+		if len(res) != 1 {
+			return errorLogger(fmt.Errorf("expected 1 result but got %d", len(res)))
+		}
+		found, ok := res[0].Val.(int64)
+		if !ok {
+			return errorLogger(fmt.Errorf("expected int result but got %v of type %v", res[0].Val, reflect.TypeOf(res[0].Val)))
+		}
+
+		if found != 1 {
+			fmt.Println("a new universe is born")
+			universe.Randomize(50)
+			universe.Read(localState)
+			err := db.Set(key, localState)
+			if err != nil {
+				return errorLogger(err)
+			}
+		}
+
+		fmt.Println("fetching existing universe")
+		remoteState, err = db.Get(key)
+		if err != nil {
+			return errorLogger(err)
+		}
+
+		universe.Read(remoteState)
+		universe.Tick()
+
+		universe.Read(localState)
+
+		err = db.Set(key, localState)
+		if err != nil {
+			return errorLogger(err)
+		}
+
+		msg := stringID
+		for i := uint32(0); i < height; i++ {
+			idx := universe.GetIndex(i, width-1)
+			msg = msg + strconv.Itoa(int(universe.Cell(idx)))
+		}
+
+		fmt.Println("emitting new event")
+		fmt.Println(msg)
+
+		db.Publish("universe", []byte(msg))
+
+		return nil
+	})
+}
+
+// main functiion must be included for the compiler but is not executed.
+func main() {}
+
+func errorLogger(err error) error {
+	fmt.Fprintf(os.Stderr, "Error: %v", err.Error())
+	return err
+}

--- a/multiverse/wasi.go
+++ b/multiverse/wasi.go
@@ -81,7 +81,7 @@ func init() {
 			return errorLogger(err)
 		}
 
-		universe.Read(remoteState)
+		universe.Write(remoteState)
 		universe.Tick()
 
 		universe.Read(localState)

--- a/multiverse/wasi.go
+++ b/multiverse/wasi.go
@@ -52,7 +52,7 @@ func init() {
 
 		db := redis.NewClient(redisHost)
 
-		universe := game.NewUniverse(height, width)
+		universe := game.NewMultiverse(height, width)
 		res, err := db.Execute("EXISTS", key)
 		if err != nil {
 			return errorLogger(err)
@@ -82,7 +82,28 @@ func init() {
 		}
 
 		universe.Write(remoteState)
+
+		fmt.Println("making contact")
+		incomingColumn := make([]uint8, height)
+		for idx, cell := range incomingMsg[1:] {
+			switch cell {
+			case '1':
+				incomingColumn[idx] = game.Alive
+			case '0':
+				incomingColumn[idx] = game.Dead
+			}
+		}
+		universe.MakeContact(incomingColumn)
+
+		drawing := universe.Draw()
+		fmt.Println("Before")
+		fmt.Println(drawing)
+
 		universe.Tick()
+
+		drawing = universe.Draw()
+		fmt.Println("After")
+		fmt.Println(drawing)
 
 		universe.Read(localState)
 

--- a/spin.toml
+++ b/spin.toml
@@ -1,0 +1,27 @@
+spin_manifest_version = 2
+
+[application]
+name = "vita"
+version = "0.1.0"
+authors = ["Alessandro Cifani <alessandro.cifani@gmail.com>"]
+description = ""
+
+[variables]
+local_id = { required = true }
+
+[application.trigger.redis]
+address = "redis://localhost:6379"
+
+[[trigger.redis]]
+channel = "universe"
+component = "vita-wasi"
+
+[component.vita-wasi]
+source = "./multiverse/wasi.wasm"
+allowed_outbound_hosts = ["redis://localhost:6379"]
+[component.vita-wasi.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o ./multiverse/wasi.wasm ./multiverse/wasi.go"
+watch = ["**/*.go", "go.mod"]
+[component.vita-wasi.variables]
+local_id = "{{ local_id }}"
+redis_host = "redis://localhost:6379"


### PR DESCRIPTION
- Implement a rough draft of a multiverse. A universe can make contact with other universes by reading an incoming extra column that will be used in calculating the next generation. That column is not updated automatically at the moment - it's kept as read-only and won't change unless contact is made again. This needs to be expanded 
- Implement a WASI function triggered by messages on a Redis pubsub channel. Each message contains the incoming universe ID in the first character and then a single column that other universes can use. The state is updated and the universe publishes its last column in the same channel