### PR TITLE
lib/game: fix error in random function

### DIFF
--- a/lib/game/rand.go
+++ b/lib/game/rand.go
@@ -7,7 +7,7 @@ import (
 func randomNumber() int {
 	var b [1]byte
 	rand.Read(b[:])
-	val := int(b[0])
+	val := int(b[0]) >> 1
 	if val > 100 {
 		val = val >> 1
 	}


### PR DESCRIPTION
This PR fixes an error in random function, since `crypto/rand` will return a 8-bit random number.